### PR TITLE
Add 'test' and 'sample' modes (for RBM/DBN on MNIST)

### DIFF
--- a/IO.py
+++ b/IO.py
@@ -11,13 +11,18 @@ def load_mnist(dataset='train'):
         fn = 'datasets/MNIST/t10k-images-idx3-ubyte'
         fn2 = 'datasets/MNIST/t10k-labels-idx1-ubyte'
 
+    print("Loading MNIST dataset...")
     #parse the matrix file into temporary files for each header item
     with open(fn,'rb') as f:
+        print("Loading images...")
         magic_nr, N, rows, cols = struct.unpack(">IIII", f.read(16))
+        print("Magic number: %s; N: %s; rows: %s; cols: %s" % (magic_nr, N, rows, cols))
         img = array("B", f.read())
 
     with open(fn2, 'rb') as g:
+        print("Loading labels...")
         magic_nr, size = struct.unpack(">II", g.read(8))
+        print("Magic number: %s; N: %s" % (magic_nr, size))
         lbl = array("b", g.read())
 
     ind = [k for k in range(N)]
@@ -29,4 +34,4 @@ def load_mnist(dataset='train'):
         images[i] = np.array(img[ind[i]*rows*cols:(ind[i]+1)*rows*cols])
         labels[i] = lbl[ind[i]]
 
-    return N, images, labels
+    return images, labels

--- a/IO.py
+++ b/IO.py
@@ -11,7 +11,7 @@ def load_mnist(dataset='train'):
         fn = 'datasets/MNIST/t10k-images-idx3-ubyte'
         fn2 = 'datasets/MNIST/t10k-labels-idx1-ubyte'
 
-    print("Loading MNIST dataset...")
+    print("\nLoading MNIST dataset...")
     #parse the matrix file into temporary files for each header item
     with open(fn,'rb') as f:
         print("Loading images...")
@@ -22,7 +22,7 @@ def load_mnist(dataset='train'):
     with open(fn2, 'rb') as g:
         print("Loading labels...")
         magic_nr, size = struct.unpack(">II", g.read(8))
-        print("Magic number: %s; N: %s" % (magic_nr, size))
+        print("Magic number: %s; N: %s\n" % (magic_nr, size))
         lbl = array("b", g.read())
 
     ind = [k for k in range(N)]

--- a/RBM_cmdline.py
+++ b/RBM_cmdline.py
@@ -8,14 +8,15 @@ parser = argparse.ArgumentParser(description='Train, validate/test, and sample f
 
 # Paths for saving, loading, and data retrieval
 parser.add_argument('--dataset', type=str, metavar='STR', default='MNIST', help='string specifying dataset (for now, just load MNIST)')
-parser.add_argument('--save_path', type=str, metavar='STR', default='save', help='directory to save weights at checkpoints')
+parser.add_argument('--save_path', type=str, metavar='STR', default='save', help='directory to save data (data differs depending on mode and other parameters)')
 parser.add_argument('--save_freq', type=int, metavar='INT', default=10000, help='number of iterations between checkpoints')
 parser.add_argument('--save', nargs='*', metavar='STR',type=str, default=['c','p','f','s'], help="""list of strings specifying what to save:
-                                                                         'l': training log
+                                                                         'l': training or test log
                                                                          'c': curves (error & other plots)
                                                                          'p': parameters
                                                                          'f': filter visualizations
-                                                                         's': samples from the model""")
+                                                                         's': samples from the model
+                                                                         Note: values other than 'l' ignored for tests; this argument is ignored in sample mode.""")
 parser.add_argument('--init_from', type=str, metavar='STR', default=None, help="""use model parameters stored at specified path
                                                                    --ensure that network architectures match
                                                                    --loads most recently saved file at path
@@ -66,9 +67,9 @@ if __name__ == '__main__':
 
     if args.mode in ['train','test']:
         if (args.dataset == 'MNIST'):
-            N, X, labels = load_mnist(args.mode)
+            X, labels = load_mnist(args.mode)
 
-        f(X, N, labels, config)
+        f(X, labels, config)
     else:
         f(config)
 

--- a/RBM_cmdline.py
+++ b/RBM_cmdline.py
@@ -18,10 +18,10 @@ parser.add_argument('--save', nargs='*', metavar='STR',type=str, default=['c','p
                                                                          's': samples from the model
                                                                          Note: values other than 'l' ignored for tests; this argument is ignored in sample mode.""")
 parser.add_argument('--init_from', type=str, metavar='STR', default=None, help="""use model parameters stored at specified path
-                                                                   --ensure that network architectures match
-                                                                   --loads most recently saved file at path
-                                                                   --loads saved parameters for all layers, if they exist
-                                                                   --required for 'test' and 'sample' modes""")
+                                                                                  -ensure that network architectures match
+                                                                                  -loads most recently saved file at path
+                                                                                  -loads saved parameters for all layers, if they exist
+                                                                                  -required for 'test' and 'sample' modes""")
 parser.add_argument('--train_from', type=int, metavar='INT', default=1, help='specify which layer to begin training on')
 # Hyperparameters
 parser.add_argument('--model', type=str, metavar='MODEL', default='RBM', help='currently only RBM')
@@ -32,13 +32,20 @@ parser.add_argument('--epochs', type=int, metavar='INT', default=20, help='numbe
 parser.add_argument('--alpha', type=float, metavar='FLOAT', default=0.05, help='learning rate')
 parser.add_argument('--L2_param', type=float, metavar='FLOAT', default=1e-4, help='L2 regularization parameter')
 parser.add_argument('--momentum', type=float, metavar='INT', default=0, help='Momentum parameter for SGD with momentum')
+parser.add_argument('--anneal', type=bool, metavar='BOOL', default=True, help='Boolean to toggle ')
 
 parser.add_argument('--use_probs', type=str, metavar='STR', default='both', help="Use probabilities rather than states to 'infer' (negative phase only), 'learn', 'both', or 'none'")
 parser.add_argument('--CD', type = int, metavar='INT', default=1, help="Number of steps of Gibbs sampling to use for Contrastive Divergence learning")
 
 # Mode
 parser.add_argument('--mode', type=str, metavar='STR', default='train', help='train, test, or sample')
-parser.add_argument('--num_samples', type=int, metavar='INT', default=10, help="specify number of samples to generate (for use with 'sample' mode)")
+parser.add_argument('--num_samples', type=int, metavar='INT', default=10, help="For 'sample' mode: specify number of samples to generate")
+parser.add_argument('--sample_class', nargs='*',type=int, metavar='INT', default=None, help="""For 'sample' mode: specify which classes to generate from
+                                                                                                      -if one value is provided, all samples will be from the specified class
+                                                                                                      -if more than one, class for each sample is chosen from a flat distribution""")
+parser.add_argument('--init_mode', type=str, metavar='STR', default='random', help="""specify data to use to initialize Gibbs sampling
+                                                                                     random: random vector in [0,1] 
+                                                                                     MNIST_test: random MNIST test image""")
 
 args = parser.parse_args()
 
@@ -61,15 +68,18 @@ if __name__ == '__main__':
     
     model = {'RBM': RBM}
     network = model[args.model](args.layer_sizes, args.labels, args.alpha, args.L2_param, args.momentum, args.use_probs, args.CD)
-    config = Session(network, args.model, args.mode, args.dataset, args.save, args.save_path, args.save_freq, args.init_from, args.train_from, args.epochs, args.num_samples)
+    config = Session(network, args.model, args.mode, args.dataset, args.save, args.save_path, args.save_freq, args.init_from, args.train_from, args.epochs, args.num_samples, args.sample_class, args.init_mode)
     mode = {'train': network.train, 'test': network.test, 'sample': network.sample}
     f = mode[args.mode]
 
     if args.mode in ['train','test']:
         if (args.dataset == 'MNIST'):
             X, labels = load_mnist(args.mode)
-
         f(X, labels, config)
     else:
-        f(config)
+        if args.init_mode=='MNIST_test':
+            X, _ = load_mnist('test')
+        else:
+            X = None
+        f(config, X=X)
 

--- a/session.py
+++ b/session.py
@@ -26,42 +26,11 @@ class Session(object):
 
     def startup(self):
 
-        print(self.save)
-
         def _plog(s):
             print(s)
             f.write(s+"\n")
 
-        # Initialize session, update log.txt which just stores the last session ID#
-        #sess = "[%s]" % datetime.now().strftime("%d.%m.%Y_%H:%M:%S")
-        log = 0
-        if path.exists(self.save_path + '/log.txt'):
-            log = np.fromfile(self.save_path + '/log.txt', dtype='int', count=1)[0]
-        log += 1
-        if not path.exists(self.save_path):
-            mkdir(self.save_path)
-            print("Creating folder %s/ to save data..." % self.save_path)
-        with open(self.save_path + '/log.txt', 'w') as f:
-            np.array([log]).tofile(f)
-        # Create required sub-directories if not found
-        session_path = self.save_path + '/session' + str(log)
-        if not path.exists(session_path):
-            mkdir(session_path)
-            print("Subfolder " + session_path + " created to store session info.")
-        save_dict = {'c': 'curves', 'p': 'parameters', 'f': 'filters', 's': 'samples'}
-        save_args = [x for x in self.save if x != 'l']
-        save_args = [save_dict[key] for key in save_args]
-        for subpath in save_args:
-            if not path.exists(session_path+"/"+subpath):
-                mkdir(session_path+"/"+subpath)
-                print("Subfolder " + session_path+"/"+subpath + " created to store %s." % subpath)
-                for layer in range(self.train_from, self.model.L):
-                    layer_path = session_path+"/"+subpath+"/layer%s" % layer
-                    if not path.exists(layer_path):
-                        mkdir(layer_path)
-                        print("Creating %s subfolder for layer %s" % (subpath, layer))
-
-        if self.init_from: # Routine to allow loading of previously trained parameters--currently, loads all paramters stored for the model
+        if self.init_from: # Load previously trained parameters--currently, loads all paramters stored for the model from most recent save state in path
 
             for l in range(1,self.model.L):
                 layer_path = self.init_from + ('/parameters/layer%s/' % l)
@@ -82,7 +51,40 @@ class Session(object):
                                 self.model.W[self.model.L-1] = np.reshape(struct.unpack('f'*self.model.layer_sizes[l]*self.model.num_labels,f.read(data_size)),(self.model.layer_sizes[l],self.model.num_labels))
                                 self.model.b[self.model.L] = np.array(struct.unpack('f'*self.model.num_labels,f.read())) 
 
+        # Initialize session, update log.txt which just stores the last session ID#
+        log = 0
+        session_path = ''
+        if self.save:
+            fn = '/%s_log.txt' % self.mode
+            if path.exists(self.save_path + fn):
+                log = np.fromfile(self.save_path + fn, dtype='int', count=1)[0]
+            log += 1
+            if not path.exists(self.save_path):
+                mkdir(self.save_path)
+                print("Creating folder %s/ to save data..." % self.save_path)
+            with open(self.save_path + fn, 'w') as f:
+                np.array([log]).tofile(f)
+            # Create required sub-directories if not found
+            session_path = self.save_path + ('/%s_session' % self.mode) + str(log)
+            if not path.exists(session_path):
+                mkdir(session_path)
+                print("Subfolder " + session_path + " created to store session info.")
+
         if self.mode == 'train':
+
+            save_dict = {'c': 'curves', 'p': 'parameters', 'f': 'filters', 's': 'samples'}
+            save_args = [x for x in self.save if x != 'l']
+            save_args = [save_dict[key] for key in save_args]
+            for subpath in save_args:
+                if not path.exists(session_path+"/"+subpath):
+                    mkdir(session_path+"/"+subpath)
+                    print("Subfolder " + session_path+"/"+subpath + " created to store %s." % subpath)
+                    for layer in range(self.train_from, self.model.L):
+                        layer_path = session_path+"/"+subpath+"/layer%s" % layer
+                        if not path.exists(layer_path):
+                            mkdir(layer_path)
+                            print("Creating %s subfolder for layer %s" % (subpath, layer))
+
             print("\nTraining %s (usng SGD) on dataset \'%s\' with hyperparameters:\n" % (self.modelname, self.dataset))
 
             with open(session_path+'/config.txt', 'w') as f:
@@ -126,5 +128,11 @@ class Session(object):
             if 'l' in self.save:
                 print("Maintaining training log")
             print("\n")
+
+        elif self.mode == 'test':
+            print("\nTesting the model stored at %s on the \'%s\' dataset, using %s steps of Gibbs sampling.\n" % (self.init_from, self.dataset, self.model.CD))
+
+        elif self.mode == 'sample':
+            print("\nDrawing %s samples from the model stored at %s, using %s steps of Gibbs sampling.\n" % (self.num_samples, self.init_from, self.model.CD))
 
         return log, session_path

--- a/session.py
+++ b/session.py
@@ -6,7 +6,7 @@ from os import path, mkdir
 
 class Session(object):
 
-    def __init__(self, model, modelname='RBM', mode='train', dataset='MNIST', save=['c','p','f','s'], save_path='save', save_freq=2000, init_from=None, train_from=1, epochs=20, num_samples=10):
+    def __init__(self, model, modelname='RBM', mode='train', dataset='MNIST', save=['c','p','f','s'], save_path='save', save_freq=2000, init_from=None, train_from=1, epochs=20, num_samples=10, sample_class=None, init_mode='random'):
 
         # Check consistency of settings
         assert train_from < model.L, "Cannot begin training from hidden layer %s in a model with %s hidden layers." % (train_from, model.L-1)
@@ -18,6 +18,8 @@ class Session(object):
         self.train_from = train_from
         self.epochs = epochs
         self.num_samples = num_samples
+        self.sample_class = sample_class
+        self.init_mode = init_mode
 
         self.model = model
         self.modelname = modelname
@@ -38,6 +40,7 @@ class Session(object):
                     log_list = glob.glob('%s*' % layer_path)
                     if log_list:
                         latest = max(log_list, key=path.getctime)
+                        print("Loading saved parameters for layer %s..." % l)
                         with open(latest,'rb') as f:
                             data_size = struct.calcsize('f'*self.model.layer_sizes[l]*self.model.layer_sizes[l-1])
                             self.model.W[l-1] = np.reshape(struct.unpack('f'*self.model.layer_sizes[l]*self.model.layer_sizes[l-1],f.read(data_size)),(self.model.layer_sizes[l],self.model.layer_sizes[l-1]))
@@ -49,7 +52,8 @@ class Session(object):
                             if (self.model.num_labels and l == self.model.L-1):
                                 data_size = struct.calcsize('f'*self.model.layer_sizes[l]*self.model.num_labels)
                                 self.model.W[self.model.L-1] = np.reshape(struct.unpack('f'*self.model.layer_sizes[l]*self.model.num_labels,f.read(data_size)),(self.model.layer_sizes[l],self.model.num_labels))
-                                self.model.b[self.model.L] = np.array(struct.unpack('f'*self.model.num_labels,f.read())) 
+                                self.model.b[self.model.L] = np.array(struct.unpack('f'*self.model.num_labels,f.read()))
+            print("")
 
         # Initialize session, update log.txt which just stores the last session ID#
         log = 0
@@ -61,7 +65,7 @@ class Session(object):
             log += 1
             if not path.exists(self.save_path):
                 mkdir(self.save_path)
-                print("Creating folder %s/ to save data..." % self.save_path)
+                print("\nCreating folder %s/ to save data..." % self.save_path)
             with open(self.save_path + fn, 'w') as f:
                 np.array([log]).tofile(f)
             # Create required sub-directories if not found
@@ -114,7 +118,10 @@ class Session(object):
                 print("For %s epochs\n" % self.epochs)
                 f.write("Epochs: %s" % self.epochs + "\n")
                 if self.init_from:
-                    s = "Beginning with the parameters stored in " + self.init_from + "\n"
+                    s = "Beginning with the parameters stored in " + self.init_from
+                    _plog(s)
+                if self.train_from:
+                    s = "Starting traning at layer %s" % self.train_from
                     _plog(s)
 
             if save_args:
@@ -133,6 +140,8 @@ class Session(object):
             print("\nTesting the model stored at %s on the \'%s\' dataset, using %s steps of Gibbs sampling.\n" % (self.init_from, self.dataset, self.model.CD))
 
         elif self.mode == 'sample':
-            print("\nDrawing %s samples from the model stored at %s, using %s steps of Gibbs sampling.\n" % (self.num_samples, self.init_from, self.model.CD))
+            print("\nDrawing %s samples from the model stored at %s, using %s step(s) of Gibbs sampling.\n" % (self.num_samples, self.init_from, self.model.CD))
+            if self.sample_class:
+                print("Label units clamped to class(es) %s" % self.sample_class)
 
         return log, session_path


### PR DESCRIPTION
I'm not confident that these algorithms are properly implemented yet based on performance, but they do seem to function minimally as intended.

Summary of changes:
- Added 'test' mode: loads the test dataset (so far, just the 10,000 MNIST test images) and samples a label value for each image, using `CD` iterations of Gibbs sampling, as described in https://www.cs.toronto.edu/~hinton/absps/tics.pdf.
- Added 'sample' mode: Markov chain (using `CD` iterations of Gibbs sampling) is run, then states of the input layer are fantasized. The Markov chain can be initialized using (so far) a random noise vector or a random test case, at the input layer.
-  Fixed a bug (of sorts) in the `train` code (for RBM/DBN): probabilities, rather than sampled states, are now used for the "input layer" at any level of a DBN, regardless of the `use_probs` setting. (As recommended in https://www.cs.toronto.edu/~hinton/absps/montrealTR.pdf). This seems to greatly improve the reconstruction error, though the jury's still out about whether it improves the model.
- Added histogram plots for parameters and gradients (saved along with cost plots if `save c`(curves) is enabled).
- Various other small fixes.